### PR TITLE
Fix Cloudflare Pages guide link

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -37,7 +37,7 @@ export default function HomePage() {
         </div>
         <div className="flex flex-col items-center gap-3 sm:flex-row">
           <Button asChild size="lg">
-            <Link href="https://developers.cloudflare.com/pages/framework-guides/deploy-a-nextjs-site/">
+            <Link href="https://developers.cloudflare.com/pages/framework-guides/nextjs/">
               View Cloudflare Pages guide
             </Link>
           </Button>


### PR DESCRIPTION
## Summary
- update the landing page button to point to the current Cloudflare Pages Next.js guide

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68e0cd6d0af4832d93d844a75931056e