### PR TITLE
fix: unblock dashboard-managed bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A modern Next.js scaffold that runs natively on [Cloudflare Pages](https://devel
 - **Next.js App Router** configured for TypeScript
 - **Tailwind CSS 3** with shadcn/ui primitives and helper utilities
 - **Cloudflare Pages ready** via [`@cloudflare/next-on-pages`](https://github.com/cloudflare/next-on-pages) and Wrangler scripts
+- **Batteries included with D1 + R2** helpers, bindings, and docs for database queries and object storage access on the Edge runtime
 - **Strict linting** using `eslint-config-next`
 - Example API route running on the Edge Runtime plus UI components to kickstart development
 
@@ -50,9 +51,30 @@ Open <http://localhost:3000> to view the application.
 5. Save the configuration and click **Deploy site**. Cloudflare Pages will run the build command and publish the static assets and functions defined in the `.vercel/output` folder.
 6. After the first deployment completes, open the project in the Pages dashboard, go to **Settings → Functions → Compatibility flags**, and add `nodejs_compat` to both the production and preview environments so Node.js built-ins used by Next.js are available at runtime.
 
+### Connecting D1 and R2
+
+This scaffold exposes bindings for Cloudflare [D1](https://developers.cloudflare.com/d1/) and [R2](https://developers.cloudflare.com/r2/) so you can work with relational data and object storage directly from the Edge runtime.
+
+1. Create a D1 database and R2 bucket:
+
+   ```bash
+   wrangler d1 create nextjs-cloudflare-starter-db
+   wrangler r2 bucket create nextjs-cloudflare-starter-assets
+   ```
+
+2. Update the placeholders in `wrangler.preview.toml` with the IDs/names returned by Wrangler **only if you plan to run `pnpm cf:preview` locally**. These bindings are declared as `DB` (D1) and `R2` (object storage) so the sample API route can discover them automatically.
+3. When deploying through Cloudflare Pages you can attach the same resources in the dashboard without touching the repository because the production `wrangler.toml` intentionally omits binding declarations:
+   - Go to **Pages → _your project_ → Settings → Functions** and add the D1 database under **D1 Databases** with the binding name `DB`.
+   - In the same screen, add the R2 bucket under **R2 Buckets** with the binding name `R2`.
+   - Because the scaffold already imports these binding names, no code change is required for production deployments.
+4. Re-run `pnpm cf:build` followed by `pnpm cf:preview` to test locally, or push to your Git provider to deploy.
+   - Cloudflare Pages will now allow you to manage D1 and R2 bindings directly in the dashboard because the repository no longer declares them for production builds.
+
+The sample API route at `/api/hello` automatically detects whether the bindings are configured. When both are available it will run a simple D1 query and list up to five R2 object keys to confirm the integration.
+
 ### Local preview
 
-The included `wrangler.toml` and `pnpm cf:preview` script let you test the same build locally before pushing to Git. Run:
+The included `wrangler.preview.toml` and `pnpm cf:preview` script let you test the same build locally before pushing to Git. Run:
 
 ```bash
 pnpm cf:build
@@ -79,5 +101,10 @@ components/     # Reusable UI components (shadcn/ui)
 lib/            # Shared utilities
 public/         # Static assets
 ```
+
+## Troubleshooting
+
+- If `pnpm dev` fails with `Module not found: Can't resolve '@cloudflare/next-on-pages'`, ensure the dependencies have been
+  installed by running `pnpm install` (or `pnpm install --frozen-lockfile` in CI) before starting the development server.
 
 Happy shipping! 🚀

--- a/app/api/hello/route.ts
+++ b/app/api/hello/route.ts
@@ -1,8 +1,64 @@
 import { NextResponse } from "next/server";
 
+import { getOptionalEnv } from "@/lib/cloudflare";
+
 export const runtime = "edge";
 
 export async function GET() {
+  const env = getOptionalEnv();
+
+  const d1 = await (async () => {
+    if (!env?.DB) {
+      return {
+        configured: false,
+        message:
+          "Add a D1 binding named `DB` in wrangler.toml to query your database from the Edge runtime.",
+      } as const;
+    }
+
+    try {
+      const { results } = await env.DB.prepare(
+        "SELECT datetime('now') AS currentTime, 'D1 is ready to use 🚀' AS message"
+      ).all();
+
+      return {
+        configured: true,
+        results,
+      } as const;
+    } catch (error) {
+      return {
+        configured: false,
+        message: "The D1 binding is defined but the query failed.",
+        error: error instanceof Error ? error.message : String(error),
+      } as const;
+    }
+  })();
+
+  const r2 = await (async () => {
+    if (!env?.R2) {
+      return {
+        configured: false,
+        message:
+          "Add an R2 binding named `R2` in wrangler.toml to access your bucket from the Edge runtime.",
+      } as const;
+    }
+
+    try {
+      const { objects } = await env.R2.list({ limit: 5 });
+
+      return {
+        configured: true,
+        sampleKeys: objects.map((object) => object.key),
+      } as const;
+    } catch (error) {
+      return {
+        configured: false,
+        message: "The R2 binding is defined but listing objects failed.",
+        error: error instanceof Error ? error.message : String(error),
+      } as const;
+    }
+  })();
+
   return NextResponse.json({
     message: "Hello from Cloudflare Pages!",
     docs: {
@@ -10,6 +66,12 @@ export async function GET() {
       tailwind: "https://tailwindcss.com/docs",
       shadcn: "https://ui.shadcn.com",
       cloudflare: "https://developers.cloudflare.com/pages/",
+      d1: "https://developers.cloudflare.com/d1/",
+      r2: "https://developers.cloudflare.com/r2/",
+    },
+    integrations: {
+      d1,
+      r2,
     },
   });
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,6 +9,11 @@ const highlights = [
       "Preconfigured build commands and wrangler tooling tailored for Cloudflare Pages deployments.",
   },
   {
+    title: "D1 + R2 ready",
+    description:
+      "Edge API routes demonstrate how to run database queries and list objects using Cloudflare D1 and R2 bindings.",
+  },
+  {
     title: "Modern UI",
     description:
       "Tailwind CSS 3 with shadcn/ui primitives let you craft accessible interfaces quickly.",

--- a/lib/cloudflare.ts
+++ b/lib/cloudflare.ts
@@ -1,0 +1,17 @@
+import { getOptionalRequestContext, getRequestContext } from "@cloudflare/next-on-pages";
+
+export type CloudflareBindings = CloudflareEnv;
+
+export function getSafeRequestContext():
+  | ReturnType<typeof getRequestContext>
+  | null {
+  try {
+    return getRequestContext();
+  } catch (error) {
+    return null;
+  }
+}
+
+export function getOptionalEnv(): CloudflareEnv | null {
+  return getOptionalRequestContext()?.env ?? getSafeRequestContext()?.env ?? null;
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "lint": "next lint",
     "cf:build": "next-on-pages",
-    "cf:preview": "wrangler pages dev .vercel/output/static --compatibility-date=2024-05-01"
+    "cf:preview": "wrangler pages dev .vercel/output/static --config wrangler.preview.toml --compatibility-date=2024-05-01"
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.1.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -43,6 +43,7 @@
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
+    "types/**/*.d.ts",
     ".next/types/**/*.ts"
   ],
   "exclude": [

--- a/types/cloudflare-env.d.ts
+++ b/types/cloudflare-env.d.ts
@@ -1,0 +1,10 @@
+import type { D1Database, R2Bucket } from "@cloudflare/workers-types";
+
+export {};
+
+declare global {
+  interface CloudflareEnv {
+    DB?: D1Database;
+    R2?: R2Bucket;
+  }
+}

--- a/wrangler.preview.toml
+++ b/wrangler.preview.toml
@@ -1,0 +1,18 @@
+name = "nextjs-cloudflare-starter-preview"
+compatibility_date = "2024-05-01"
+compatibility_flags = ["nodejs_compat"]
+pages_build_output_dir = ".vercel/output/static"
+
+[vars]
+NEXT_ON_PAGES = "1"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "nextjs-cloudflare-starter-db"
+# Replace with the database ID from `wrangler d1 create`
+database_id = "00000000-0000-0000-0000-000000000000"
+
+[[r2_buckets]]
+binding = "R2"
+# Replace with the bucket name created via `wrangler r2 bucket create`
+bucket_name = "nextjs-cloudflare-starter-assets"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,3 +5,6 @@ pages_build_output_dir = ".vercel/output/static"
 
 [vars]
 NEXT_ON_PAGES = "1"
+
+# Local-only bindings live in `wrangler.preview.toml` so production deployments can
+# be configured directly in the Cloudflare Pages dashboard.


### PR DESCRIPTION
## Summary
- augment the Cloudflare helper with safe accessors and global env typings so builds succeed even when bindings are undefined
- add a preview-only Wrangler configuration and update scripts so production deployments can manage D1/R2 bindings from the Pages dashboard
- refresh the documentation to explain the new workflow for configuring bindings locally vs. in production

## Testing
- pnpm lint
- pnpm cf:build
- pnpm tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68e1099e6874832d9ec1c19caaf9dcfd